### PR TITLE
Fixed start bug for source servers. Tamper protection file resided in other folder.

### DIFF
--- a/lib/plugins/srcds.js
+++ b/lib/plugins/srcds.js
@@ -68,17 +68,19 @@ settings.preflight = function(config, serverPath, callback) {
 	//callback();
 
 	var storedFile, userFile;
+	storedFilePath = path.normalize(serverPath + '/../srcds_run');
+	userFilePath = path.join(serverPath, 'srcds_run');
 	async.series([
 		function(callback2) {
 
 			async.parallel([
 				function(callbackp) {
 
-					fs.readFile(path.join(serverPath, 'srcds_run'), function (err, data) {
+					fs.readFile(userFilePath, function (err, data) {
 
 						if(err) {
 
-							log.error("Error detected while trying to open and read /home/" + config.user + "/srcds_run", err);
+							log.error("Error detected while trying to open and read " + userFilePath, err);
 							log.error(err.message);
 
 						} else {
@@ -93,11 +95,11 @@ settings.preflight = function(config, serverPath, callback) {
 				},
 				function(callbackp) {
 
-					fs.readFile('/home/' + config.user + '/srcds_run', function (err, data) {
+					fs.readFile(storedFilePath, function (err, data) {
 
 						if(err) {
 
-							log.error("Error detected while trying to open and read /home/" + config.user + "/srcds_run", err);
+							log.error("Error detected while trying to open and read " + storedFilePath, err);
 							log.error(err.message);
 
 						} else {
@@ -127,7 +129,7 @@ settings.preflight = function(config, serverPath, callback) {
 
 				// Tampered File
 				log.warn("Detected srcds_run as being tampered with. Replacing this file now.");
-				fs.copy('/home/' + config.user + '/srcds_run', path.join(serverPath, 'srcds_run'), function(error) {
+				fs.copy(storedFilePath, userFilePath), function(error) {
 
 					if(error) {
 						log.error("An error occured while trying to overwrite changes to srcds_run due to a file hash mismatch.", error);


### PR DESCRIPTION
Seemingly the install script doesn't make home folders but adds the games to the basepath of Scales. After that it copies the srcds_run file to the users base folder which is in this case situated inside the Scales folder. (ex. /srv/scales/pp-insurg_m7nyx/)
The launch script is hardcoded to look at the home folder(/home/pp-insurg_m7nyx) which in this case will return an error because the file doesn't exist in that path.

Pointing at the correct path makes the server start just as it is supposed to start.
