### PR TITLE
Fix process issue with kill failure on children.

### DIFF
--- a/lib/controller/system.js
+++ b/lib/controller/system.js
@@ -71,7 +71,7 @@ SystemControl.prototype.kill = function (next) {
         Logger.verbose(Util.format('Killed docker container for server %s', user));
     } else {
         if (typeof serverProcess !== 'undefined') {
-            Proc.execSync(Util.format('kill -9 $(pgrep -P $(pgrep -P %s))', serverProcess.pid));
+            Proc.execSync(Util.format('killall -u %s java', user));
             //serverProcess.kill('SIGINT');
         }
     }


### PR DESCRIPTION
Since each server runs under its own user, this fixes the behavior when your server spawns children processes this ensures all tasks get killed rather than just the original PID.
